### PR TITLE
fix: disable lockFileMaintenace

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
           "npmDedupe"
         ],
         "lockFileMaintenance": {
-          "enabled": true,
+          "enabled": false,
           "schedule": [
             "before 3am on the first day of the month"
           ]


### PR DESCRIPTION
Currently, we have a problem due to the update by lockfile maintenance feature.

> Error: Cannot find module 'nan'

`nan` seems to be an optional dependency for macOS.
It is a dependency of `fsevents`, and `fsevents` is an optional dependency of `chokidar`.
I'm not sure, but it seems to be removed when the lock file is created on Linux or Windows.

I'll investigate it later, but I'd like to disable the update now.