### PR TITLE
fix: re-disable lockFileMaintenance by removing the section

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,6 @@
         "postUpdateOptions": [
           "npmDedupe"
         ],
-        "lockFileMaintenance": {
-          "enabled": false,
-          "schedule": [
-            "before 3am on the first day of the month"
-          ]
-        },
         "packageRules": [
           {
             "groupName": "ESLint and Prettier",


### PR DESCRIPTION
We have still seen a PR for lockFileMaintenance at the scheduled time. So I've removed the section to disable it.