### PR TITLE
fix: create a PR immediately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     ":prConcurrentLimit10",
     ":timezone(Asia/Tokyo)",
     "group:monorepos",
-    ":widenPeerDependencies"
+    ":widenPeerDependencies",
+    ":prImmediately"
   ],
   "npm": {
     "extends": [


### PR DESCRIPTION
Renovate won't create PRs in the repositories don't run GitHub Action when pushing branches.
The setting is intented to use with `unpublishSafe`, but it seems not to work intentionally.
https://github.com/kintone/js-sdk/pull/610 (This doesn't have a status check for Renovate's unpublishSafe)

If we see any problem with this change, I'll revert it immidiately.