### PR TITLE
fix: config migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,13 +27,13 @@
     ],
     "packageRules": [
       {
-        "packagePatterns": [
+        "matchPackagePatterns": [
           "*"
         ],
         "semanticCommitType": "chore"
       },
       {
-        "depTypeList": [
+        "matchDepTypes": [
           "dependencies",
           "peerDependencies"
         ],
@@ -41,25 +41,25 @@
       },
       {
         "groupName": "ESLint and Prettier",
-        "packageNames": [
+        "matchPackageNames": [
           "eslint",
           "prettier"
         ],
-        "packagePatterns": [
+        "matchPackagePatterns": [
           "^eslint-config-",
           "^eslint-plugin-"
         ]
       },
       {
         "description": "automerge minor updates of widely used libraries in devDeps",
-        "updateTypes": [
+        "matchUpdateTypes": [
           "minor"
         ],
-        "depTypeList": [
+        "matchDepTypes": [
           "devDependencies"
         ],
         "automerge": true,
-        "packageNames": [
+        "matchPackageNames": [
           "glob",
           "mocha",
           "npm-run-all",
@@ -70,7 +70,7 @@
       },
       {
         "description": "disable package.json > engines update",
-        "depTypeList": [
+        "matchDepTypes": [
           "engines"
         ],
         "enabled": false
@@ -89,7 +89,7 @@
     "packageRules": [
       {
         "groupName": "Node Docker digests in CircleCI",
-        "packageNames": [
+        "matchPackageNames": [
           "circleci/node",
           "node"
         ]


### PR DESCRIPTION
renovate-config-validatorの警告に対応してみました

`npx --package renovate -c 'renovate-config-validator'`
修正後
<img width="1163" alt="スクリーンショット 2022-10-28 23 18 51" src="https://user-images.githubusercontent.com/233012/198641550-d1a1f2a0-b430-4fc2-83a1-f11c72281f10.png">


修正前
```
 INFO: Validating renovate.json
 WARN: Config migration necessary
       "oldConfig": {
         "extends": [
           ":ignoreModulesAndTests",
           ":label(renovate)",
           ":prConcurrentLimit10",
           ":timezone(Asia/Tokyo)",
           "group:monorepos",
           ":widenPeerDependencies",
           ":prImmediately",
           ":dependencyDashboard"
         ],
         "npm": {
           "extends": [
             ":automergePatch",
             ":noUnscheduledUpdates",
             ":separatePatchReleases",
             "npm:unpublishSafe",
             "helpers:disableTypesNodeMajor"
           ],
           "schedule": ["after 9pm", "before 9am"],
           "rangeStrategy": "bump",
           "postUpdateOptions": ["npmDedupe"],
           "packageRules": [
             {"packagePatterns": ["*"], "semanticCommitType": "chore"},
             {
               "depTypeList": ["dependencies", "peerDependencies"],
               "semanticCommitType": "fix"
             },
             {
               "groupName": "ESLint and Prettier",
               "packageNames": ["eslint", "prettier"],
               "packagePatterns": ["^eslint-config-", "^eslint-plugin-"]
             },
             {
               "description": "automerge minor updates of widely used libraries in devDeps",
               "updateTypes": ["minor"],
               "depTypeList": ["devDependencies"],
               "automerge": true,
               "packageNames": [
                 "glob",
                 "mocha",
                 "npm-run-all",
                 "power-assert",
                 "rimraf",
                 "sinon"
               ]
             },
             {
               "description": "disable package.json > engines update",
               "depTypeList": ["engines"],
               "enabled": false
             }
           ]
         },
         "circleci": {
           "enabled": true,
           "automerge": true,
           "automergeType": "branch",
           "schedule": ["before 9am on Friday"],
           "semanticCommitScope": "docker",
           "semanticCommitType": "ci",
           "packageRules": [
             {
               "groupName": "Node Docker digests in CircleCI",
               "packageNames": ["circleci/node", "node"]
             }
           ]
         }
       },
       "newConfig": {
         "extends": [
           ":ignoreModulesAndTests",
           ":label(renovate)",
           ":prConcurrentLimit10",
           ":timezone(Asia/Tokyo)",
           "group:monorepos",
           ":widenPeerDependencies",
           ":prImmediately",
           ":dependencyDashboard"
         ],
         "npm": {
           "extends": [
             ":automergePatch",
             ":noUnscheduledUpdates",
             ":separatePatchReleases",
             "npm:unpublishSafe",
             "helpers:disableTypesNodeMajor"
           ],
           "schedule": ["after 9pm", "before 9am"],
           "rangeStrategy": "bump",
           "postUpdateOptions": ["npmDedupe"],
           "packageRules": [
             {"matchPackagePatterns": ["*"], "semanticCommitType": "chore"},
             {
               "matchDepTypes": ["dependencies", "peerDependencies"],
               "semanticCommitType": "fix"
             },
             {
               "groupName": "ESLint and Prettier",
               "matchPackageNames": ["eslint", "prettier"],
               "matchPackagePatterns": ["^eslint-config-", "^eslint-plugin-"]
             },
             {
               "description": "automerge minor updates of widely used libraries in devDeps",
               "matchUpdateTypes": ["minor"],
               "matchDepTypes": ["devDependencies"],
               "automerge": true,
               "matchPackageNames": [
                 "glob",
                 "mocha",
                 "npm-run-all",
                 "power-assert",
                 "rimraf",
                 "sinon"
               ]
             },
             {
               "description": "disable package.json > engines update",
               "matchDepTypes": ["engines"],
               "enabled": false
             }
           ]
         },
         "circleci": {
           "enabled": true,
           "automerge": true,
           "automergeType": "branch",
           "schedule": ["before 9am on Friday"],
           "semanticCommitScope": "docker",
           "semanticCommitType": "ci",
           "packageRules": [
             {
               "groupName": "Node Docker digests in CircleCI",
               "matchPackageNames": ["circleci/node", "node"]
             }
           ]
         }
       }
 INFO: Config validated successfully
```