### PR TITLE
feat: use `pinDigests` to third party actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -95,5 +95,17 @@
         ]
       }
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "excludePackagePrefixes": [
+        "actions/",
+        "cybozu/"
+      ],
+      "pinDigests": true
+    }
+  ]
 }


### PR DESCRIPTION
## Why

Using digest pinning is the most secure way to manage third-party actions.

> Using the commit SHA of a released action version is the safest for stability and security.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses

## What

- enable `pinDigests` to third-party actions

ref: https://zenn.dev/tasshi/articles/renovate-pin-third-party-actions

## How to test

N/A
