### PR TITLE
feat: add minimumReleaseAge setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+.vscode
+.idea

--- a/default.json
+++ b/default.json
@@ -21,6 +21,7 @@
       "after 9pm",
       "before 9am"
     ],
+    "minimumReleaseAge": "14 days",
     "rangeStrategy": "bump",
     "postUpdateOptions": [
       "npmDedupe"


### PR DESCRIPTION
## Why

ref. https://docs.renovatebot.com/configuration-options/#minimumreleaseage

## What

- set minimumReleaseAge 14 days for npm packages