### PR TITLE
chore: Modify CODEOWNERS for new default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This file controls default reviewers.
-* @shisama @b4h0-c4t @sajikix
+* @cybozu/renovate-config # https://github.com/orgs/cybozu/teams/renovate-config/members


### PR DESCRIPTION
Updated CODEOWNERS to include cybozu/renovate-config.